### PR TITLE
ADD - 프로필 화면 레이아웃 구현

### DIFF
--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,11 +1,42 @@
 import BottomNavBar from '@components/common/BottomNavBar';
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 10px 20px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+`;
+
+const InfoCard = styled.div`
+  width: 100%;
+  max-width: 400px;
+  padding: 20px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+`;
 
 const ProfilePage = () => {
   return (
-    <>
-      <div>ProfilePage</div>
+    <Container>
+      <ContentWrapper>
+        <InfoCard>3 학습한 카드</InfoCard>
+        <InfoCard>1 완료한 퀴즈</InfoCard>
+      </ContentWrapper>
       <BottomNavBar />
-    </>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## 📚 개요

프로필 화면 레이아웃을 구현했습니다.
나중에 추가로 정보를 더 넣을 수도 있을 것 같습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

<img width="427" height="782" alt="image" src="https://github.com/user-attachments/assets/5352d2dd-672d-4386-9a57-bc1e418185bb" />