### PR TITLE
EDIT - 홈화면, 학습화면 글자 크기 조절

### DIFF
--- a/src/components/education/FlippableCard.tsx
+++ b/src/components/education/FlippableCard.tsx
@@ -50,9 +50,9 @@ const CardHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 1rem;
+  font-size: 24px;
   color: #6c757d;
-  height: 4rem;
+  height: 100px;
 `;
 
 const CardDescriptionContainer = styled.div`
@@ -69,8 +69,8 @@ const CardCategory = styled.span`
 const CardDifficulty = styled.span``;
 
 const CardTitle = styled.div`
-  font-size: 1.5rem;
-  font-weight: bold;
+  font-size: 30px;
+  font-weight: 700;
   text-align: center;
   margin: auto 0;
   color: #343a40;
@@ -90,15 +90,15 @@ const ActionButton = styled.button`
 `;
 
 const InfoTitle = styled.div`
-  font-weight: bold;
-  font-size: 1.5rem;
+  font-weight: 700;
+  font-size: 20px;
   color: #495057;
   margin-bottom: 5px;
   height: 2rem;
 `;
 
 const CardText = styled.div`
-  font-size: 1rem;
+  font-size: 20px;
   color: #212529;
   margin-bottom: 15px;
   line-height: 1.6;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -129,9 +129,9 @@ const UserNicknameText = styled.p`
 `;
 
 const UserCharacterNameText = styled.p`
-  font-size: 16px;
+  font-size: 20px;
   color: ${GGAMJA_COLOR.LIGHT_BROWN};
-  margin-top: 8px;
+
   line-height: 1.5;
 `;
 
@@ -148,20 +148,20 @@ const UserStatusContentWrapper = styled.div`
 `;
 
 const UserLevelContentTitle = styled.p`
-  font-size: 16px;
+  font-size: 20px;
   color: ${GGAMJA_COLOR.LIGHT_BROWN};
-  margin: 0;
-  padding: 0 0 20px 0;
   line-height: 1.5;
-  text-align: center;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
   width: 100%;
 `;
 
 const UserStatusContentTitle = styled.p`
-  font-size: 16px;
+  font-size: 20px;
   color: ${GGAMJA_COLOR.LIGHT_BROWN};
   line-height: 1.5;
-  padding: 10px 0 10px 0;
+  padding: 0 0 10px 0;
   margin: 0;
 `;
 
@@ -279,9 +279,12 @@ const HomePage = () => {
             </GrassBackgroundWrapper>
           </UserCharacterWrapper>
           <UserNicknameText>이름 : {nickname}</UserNicknameText>
-          <UserCharacterNameText>{characterName}</UserCharacterNameText>
+
           <UserStatusContentWrapper>
-            <UserLevelContentTitle>레벨 {level}</UserLevelContentTitle>
+            <UserLevelContentTitle>
+              레벨 {level}
+              <UserCharacterNameText>{characterName}</UserCharacterNameText>
+            </UserLevelContentTitle>
             <UserStatusContentTitle>현재 경험치</UserStatusContentTitle>
             <UserStatusContentTitle>
               {points} / {endPoint}


### PR DESCRIPTION
## 📚 개요

- 홈화면 : 레벨 옆에 캐릭터 이름이 뜨게 수정했고, 글자 크기를 키웠습니다.
- 학습화면 : 카드 카테고리, 난이도 글자 크기를 rem 단위에서 px 단위로 수정했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

리뷰가 비교적 꼼꼼히 이루어져야할 부분이나 파일을 여기다 적어주거나
해당 로직에 직접 코멘트를 달아도 좋습니다